### PR TITLE
Remove run_api.bat script as it is no longer needed for server startup

### DIFF
--- a/scripts/run_api.bat
+++ b/scripts/run_api.bat
@@ -1,9 +1,0 @@
-@echo off
-cd %~dp0\..
-echo Activating virtual environment...
-call .venv\Scripts\activate
-
-echo Starting FastAPI server...
-python src\api.py
-
-pause


### PR DESCRIPTION
This pull request removes the `scripts/run_api.bat` batch script, which was previously used to activate the virtual environment and start the FastAPI server.

* Removed the `scripts/run_api.bat` script that activated the Python virtual environment and launched the FastAPI server.