### PR TITLE
Remove example usage and unused script files from the project

### DIFF
--- a/src/load_data.py
+++ b/src/load_data.py
@@ -30,29 +30,3 @@ class ElasticDataLoader:
             for fail in failed[:5]: 
                 print(f"Error: {fail}")
         return success, failed
-
-# Usage
-if __name__ == "__main__":
-    es = Elasticsearch("http://localhost:9200")
-    
-    INDEX_NAME = "tweets"
-    mapping = {
-        "mappings": {
-            "properties": {
-                "TweetID": {"type": "keyword"},
-                "CreateDate": {"type": "date", "format": "yyyy-MM-dd HH:mm:ssXXX||EEE MMM dd HH:mm:ss Z yyyy"},
-                "Antisemitic": {"type": "boolean"},
-                "text": {"type": "text"},
-                "sentiment": {"type": "keyword"}, 
-                "weapons": {"type": "keyword"}  
-            }
-        }
-    }
-    
-    loader = ElasticDataLoader(es, INDEX_NAME, mapping)
-    loader.create_index()
-    
-    csv_file = "data/tweets_injected 3.csv"
-    data = loader.load_csv(csv_file)
-    
-    loader.bulk_index(data)

--- a/src/query_service.py
+++ b/src/query_service.py
@@ -50,18 +50,3 @@ class QueryService:
         response = self.es.search(index=self.index_name, body=query, size=100)
         return response["hits"]["hits"]
 
-
-# Example usage
-if __name__ == "__main__":
-    es = Elasticsearch("http://localhost:9200")
-    index_name = "tweets"
-    
-    query_service = QueryService(es, index_name)
-    
-    # Example: Get antisemitic documents with weapons
-    antisemitic_docs = query_service.get_antisemitic_with_weapons()
-    print(f"Found {len(antisemitic_docs)} antisemitic documents with weapons")
-    
-    # Example: Get documents with multiple weapons
-    multi_weapon_docs = query_service.get_documents_with_multiple_weapons(min_weapons=2)
-    print(f"Found {len(multi_weapon_docs)} documents with 2+ weapons")


### PR DESCRIPTION
This pull request removes example usage code from both `src/load_data.py` and `src/query_service.py`. The main purpose is to clean up these modules by eliminating inline scripts and usage samples, making them more suitable for import and use in other contexts.

Code cleanup:

* Removed the example usage script from the bottom of `src/load_data.py`, including index creation, CSV loading, and bulk indexing logic.
* Removed the example usage script from the bottom of `src/query_service.py`, including instantiation of `QueryService` and sample queries for antisemitic documents and documents with multiple weapons.